### PR TITLE
WIP, ENH: support frame bounds for movie renders

### DIFF
--- a/ggmolvis/camera.py
+++ b/ggmolvis/camera.py
@@ -82,6 +82,7 @@ class Camera(GGMolvisArtist):
                mode='image',
                frame=None,
                filepath=None,
+               frame_bounds=None,
                resolution=(640, 360)):
         """Render the scene with this camera"""
         bpy.context.scene.camera = self.object
@@ -93,6 +94,7 @@ class Camera(GGMolvisArtist):
                                 filepath=filepath)
         elif mode == 'movie':
             renderer = MovieRenderer(resolution=resolution,
-                            filepath=filepath)
+                            filepath=filepath,
+                            frame_bounds=frame_bounds)
         renderer.render()
         renderer.display_in_notebook()

--- a/ggmolvis/renderer.py
+++ b/ggmolvis/renderer.py
@@ -44,7 +44,7 @@ class Renderer:
 
 
 class MovieRenderer(Renderer):
-    def __init__(self, resolution=(640, 360), filepath=None):
+    def __init__(self, resolution=(640, 360), filepath=None, frame_bounds=None):
         bpy.context.scene.render.resolution_x = resolution[0]
         bpy.context.scene.render.resolution_y = resolution[1]
         bpy.context.scene.render.filepath = filepath or tempfile.NamedTemporaryFile(suffix=".mp4").name
@@ -53,9 +53,13 @@ class MovieRenderer(Renderer):
         bpy.context.scene.render.ffmpeg.format = 'MPEG4'
         bpy.context.scene.render.ffmpeg.codec = 'H264'
         bpy.context.scene.render.ffmpeg.constant_rate_factor = 'HIGH'
+        self.frame_bounds = frame_bounds
     
     def render(self):
         # Render the movie
+        if self.frame_bounds is not None:
+            bpy.context.scene.frame_start = self.frame_bounds[0]
+            bpy.context.scene.frame_end = self.frame_bounds[1]
         bpy.ops.render.render(animation=True)
 
     def display_in_notebook(self):


### PR DESCRIPTION
* Fixes #15

* Add a new `frame_bounds` argument to `render()`, so that the start and end frame may be controlled conveniently by the user when producing a movie. I suppose the argument for why this should be available to the user vs. using raw `bpy` would be similar to the argument in favor of the original `frame` argument to render individual frames.

* I can add some regression tests, but I'll wait to see if folks actually want this. The current testsuite still passes locally at least.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
