### PR TITLE
ENH: user control of focal length

### DIFF
--- a/ggmolvis/ggmolvis.py
+++ b/ggmolvis/ggmolvis.py
@@ -191,7 +191,8 @@ class GGMolVis(GGMolvisArtist):
                  rotation: Union[np.ndarray, list] = None,
                  scale: Union[np.ndarray, list] = None,
                  color='default',
-                 material='default'):
+                 material='default',
+                 lens: float = 24.0):
         """Create a `Molecule` object and add it to the visualization.
         
         Parameters:
@@ -212,6 +213,8 @@ class GGMolVis(GGMolvisArtist):
             The color of the molecule. Default is 'default'
         material: str
             The material of the molecule. Default is 'default'
+        lens: float
+            The focal length of the camera associated with the molecule.
 
         Returns:
         --------
@@ -225,7 +228,8 @@ class GGMolVis(GGMolvisArtist):
                             location=location,
                             rotation=rotation,
                             scale=scale,
-                            material=material)
+                            material=material,
+                            lens=lens)
         self.molecules.append(molecule)
         return molecule
 

--- a/ggmolvis/sceneobjects/base.py
+++ b/ggmolvis/sceneobjects/base.py
@@ -40,6 +40,7 @@ class SceneObject(GGMolvisArtist):
         color="black",
         material="backdrop",
         style="default",
+        lens=24.0,
     ):
         self.world = World(location=location, rotation=rotation, scale=scale)
         super().__init__()
@@ -59,6 +60,7 @@ class SceneObject(GGMolvisArtist):
 
         self.world._apply_to(self.object)
         self._init_camera()
+        self.lens = lens
         self._move_to_collection()
 
         self.draw()
@@ -74,7 +76,7 @@ class SceneObject(GGMolvisArtist):
         self._style = Style(self, style)
 
     def _init_camera(self):
-        self.camera = Camera(name=f"{self.name}_camera")
+        self.camera = Camera(name=f"{self.name}_camera", lens=self.lens)
         size_obj_xyz = np.array(self.object.dimensions)
         # center of the object
         center_xyz = np.zeros(3)

--- a/ggmolvis/sceneobjects/molecules.py
+++ b/ggmolvis/sceneobjects/molecules.py
@@ -30,11 +30,13 @@ class Molecule(SceneObject):
         color="black",
         material="default",
         style: str = "spheres",
+        lens: float = 24.0,
     ):
         """Show the molecule."""
 
         self.atomgroup = atomgroup
         self.universe = atomgroup.universe
+        self.lens = lens
 
         # molecules need style name to create object
         self._style_name = style
@@ -47,6 +49,7 @@ class Molecule(SceneObject):
             color=color,
             material=material,
             style=style,
+            lens=lens,
         )
 
     def _init_style(self, style="default"):


### PR DESCRIPTION
* One of the simple/common needs for users is to adjust the "zoom." This is one way we might achieve exposing this, via the blender focal length attached to the camera that is attached to a given molecule object.

The code changes needed in the sample "North Star" reference user script (https://github.com/tylerjereddy/render_north_star) needed to take advantage of this are minimal:

```diff
--- a/probe.py
+++ b/probe.py
@@ -56,7 +56,7 @@ def main(p_config: dict):
     ggmv = GGMolVis()
     u = mda.Universe(topology_path, trajectory_path)
     system = u.select_atoms(sel_string)
-    all_mol = ggmv.molecule(system)
+    all_mol = ggmv.molecule(system, lens=80)
 
     # NOTE: manual bpy usage here for setting Blender engine--should be abstracted to ggmolvis
     bpy.context.scene.render.engine = blender_engine
```

Sample video produced looks much nicer with proper zoom: https://youtube.com/shorts/4oAKt3jfO6g?feature=share


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
