### PR TITLE
ENH: use compositor to set solid background color

### DIFF
--- a/ggmolvis/camera.py
+++ b/ggmolvis/camera.py
@@ -19,6 +19,7 @@ from .base import GGMolvisArtist
 from .world import World, Location, Rotation
 from . import SESSION
 from .renderer import Renderer, MovieRenderer
+from .compositor import _set_compositor_bg
 
 class Camera(GGMolvisArtist):
     """Class for the camera."""
@@ -82,11 +83,15 @@ class Camera(GGMolvisArtist):
                mode='image',
                frame=None,
                filepath=None,
-               resolution=(640, 360)):
+               resolution=(640, 360),
+               composite_bg_rgba=None):
         """Render the scene with this camera"""
         bpy.context.scene.camera = self.object
         if frame is not None:
             bpy.context.scene.frame_set(frame)
+
+        if composite_bg_rgba is not None:
+           _set_compositor_bg(composite_bg_rgba)
 
         if mode == 'image':        
             renderer = Renderer(resolution=resolution,

--- a/ggmolvis/compositor.py
+++ b/ggmolvis/compositor.py
@@ -1,0 +1,31 @@
+import bpy
+
+
+def _set_compositor_bg(rgba: tuple[float, float, float, float]):
+    """
+    Set a solid output background color using the compositor.
+
+    Parameters
+    ----------
+    rgba: tuple
+        The red, green, blue, and alpha float values to use
+        for the solid background color mixed in by the
+        compositor.
+    """
+    scene = bpy.context.scene
+    scene.render.use_compositing = True
+    scene.use_nodes = True
+    nodes = scene.node_tree.nodes
+    links = scene.node_tree.links
+    nodes.clear()
+    render_layers = nodes.new(type="CompositorNodeRLayers")
+    composite = nodes.new(type="CompositorNodeComposite")
+    color_node = nodes.new(type="CompositorNodeValue")
+    mix_node = nodes.new(type="CompositorNodeMixRGB")
+    color_node.outputs[0].default_value = 1.0
+    mix_node.blend_type = 'MIX'
+    mix_node.inputs[0].default_value = 1.0
+    mix_node.inputs[1].default_value = rgba
+    links.new(render_layers.outputs['Alpha'], mix_node.inputs[0])
+    links.new(render_layers.outputs['Image'], mix_node.inputs[2])
+    links.new(mix_node.outputs[0], composite.inputs[0])

--- a/ggmolvis/tests/test_compositor.py
+++ b/ggmolvis/tests/test_compositor.py
@@ -1,0 +1,27 @@
+import bpy
+from ggmolvis import compositor
+
+
+import pytest
+from numpy.testing import assert_allclose
+
+
+
+@pytest.mark.parametrize("rgba", [
+    (0.0, 0.0, 0.0, 1.0), # black
+    (0.3, 0.1, 0.9, 1.0), # mixture color
+    # compositor allows > 1.0 intensities
+    (5.0, 0.0, 0.0, 1.0),
+])
+def test_basic_background_setting(rgba):
+    # verify that a simple scene has its composited
+    # background "color" properly set
+    bpy.ops.scene.new(type='NEW')
+    bpy.ops.mesh.primitive_cube_add(size=2, location=(0, 0, 0))
+    compositor._set_compositor_bg(rgba)
+    nodes = bpy.context.scene.node_tree.nodes
+    for n in nodes:
+        if "MixRGB" in n.bl_idname:
+            actual = n.inputs[1].default_value
+            assert_allclose(actual, rgba)
+    bpy.ops.scene.delete()


### PR DESCRIPTION
* Fixes #17

* Use the Blender compositor (one of Brady's suggestions) to mix in a user-specified `rgba` tuple-based background color. Default for rendering remains to not use compositing.

* Add a crude regression test to probe that the compositor color setting properly propagates to the appropriate node. We discussed doing image comparisons on actual renders on Monday night, but I think we're hesitant because of technical issues with doing so in i.e., GitHub actions runners.

Sample diff for the simplifications this enables in the "reference" user render script (https://github.com/tylerjereddy/render_north_star), while retaining the ability to specify background color (and without affecting the scene lighting, as Brady noted for my original shims):

<details>

```diff
--- a/probe.py
+++ b/probe.py
@@ -7,20 +7,6 @@ import bpy
 import yaml
 
 
-def set_background(rgba: tuple):
-    # NOTE: manual bpy usage--this functionality should be upstreamed to ggmolvis
-    bpy.context.scene.render.film_transparent = False
-    world = bpy.context.scene.world
-    if not world.use_nodes:
-        world.use_nodes = True
-    node_tree = world.node_tree
-    bg_node = node_tree.nodes.get("Background") or node_tree.nodes.new("ShaderNodeBackground")
-    bg_node.inputs["Color"].default_value = rgba
-    output_node = node_tree.nodes.get("World Output") or node_tree.nodes.new("ShaderNodeOutputWorld")
-    if not any(link.to_node == output_node for link in bg_node.outputs[0].links):
-        node_tree.links.new(bg_node.outputs[0], output_node.inputs[0])
-
-
 def main(p_config: dict):
     """
     Parameters
@@ -67,14 +53,13 @@ def main(p_config: dict):
     bpy.context.scene.frame_start = frame_start
     bpy.context.scene.frame_end = frame_end
 
-    set_background(rgba=(background_color["red"],
-                         background_color["green"],
-                         background_color["blue"],
-                         background_color["alpha"]))
-
     all_mol.render(resolution=(blender_resolution_x, blender_resolution_y),
                    filepath=f"{render_filename}.{outfile_suffix}",
-                   mode=mode)
+                   mode=mode,
+                   composite_bg_rgba=(background_color["red"],
+                                      background_color["green"],
+                                      background_color["blue"],
+                                      background_color["alpha"]))
 
 
 if __name__ == "__main__":
```

</details>

Red `(1, 0, 0, 1)` sample with above shims:

![image](https://github.com/user-attachments/assets/8f4e6e30-419b-43f7-828d-52651b47ca97)


Yellow (`1, 1, 0, 1)` sample with above shims:

![image](https://github.com/user-attachments/assets/172ddf8a-e9a7-4610-b39c-70e5e11fa404)


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
