### PR TITLE
ENH, DOC: expose frame averaging

### DIFF
--- a/ggmolvis/base.py
+++ b/ggmolvis/base.py
@@ -41,7 +41,13 @@ class GGMolvisArtist(ABC):
         The set of all `GGMolvisArtist` objects in the session
     subframes: int
         Number of subframes to render. It will be a global setting
-        for all objects. Default is 1
+        for all objects. Default is 0. For clarity, when subframes is set to `1`
+        the total frame count will double, and when it is set to `2` the
+        total frame count will triple.
+    average: int
+        Number of flanking frames to average over--this can help reduce
+        "jittering" in movies. In contrast to `subframes`, no new frames
+        are added. It will be a global setting for all objects. Default is 0.
     """
     def __init__(self):
         # only one MNSession will be used to keep everything in sync.
@@ -123,6 +129,14 @@ class GGMolvisArtist(ABC):
     @subframes.setter
     def subframes(self, value):
         self.ggmolvis.subframes = value
+
+    @property
+    def average(self):
+        return self.ggmolvis.average
+
+    @average.setter
+    def average(self, value):
+        self.ggmolvis.average = value
 
     def _remove(self):
         """Remove the object from the session"""

--- a/ggmolvis/ggmolvis.py
+++ b/ggmolvis/ggmolvis.py
@@ -73,10 +73,16 @@ class GGMolVis(GGMolvisArtist):
         The global camera object
     subframes: int
         Number of subframes to render. It will be a global setting
-        for all objects. Default is 1
-    
+        for all objects. Default is 0. For clarity, when subframes is set to `1`
+        the total frame count will double, and when it is set to `2` the
+        total frame count will triple.
+    average: int
+        Number of flanking frames to average over--this can help reduce
+        "jittering" in movies. In contrast to `subframes`, no new frames
+        are added. It will be a global setting for all objects. Default is 0.
 
-    
+
+
     """
     def __new__(cls):
         if hasattr(SESSION, 'ggmolvis'):
@@ -109,6 +115,7 @@ class GGMolVis(GGMolvisArtist):
         self._global_camera = self.cameras[0]
 
         self._subframes = 0
+        self._average = 0
 
         # pre-defined camera position
         bpy.data.collections.get('MolecularNodes').objects.link(self._global_camera.object)
@@ -172,6 +179,16 @@ class GGMolVis(GGMolvisArtist):
         self._subframes = value
         for molecule in self.molecules:
             molecule.trajectory.subframes = value
+
+    @property
+    def average(self):
+        return self._average
+
+    @average.setter
+    def average(self, value):
+        self._average = value
+        for molecule in self.molecules:
+            molecule.trajectory.average = value
 
     def _set_scene(self):
         """Set up the scene with transparent background and CYCLES rendering."""

--- a/ggmolvis/sceneobjects/base.py
+++ b/ggmolvis/sceneobjects/base.py
@@ -47,6 +47,7 @@ class SceneObject(GGMolvisArtist):
         self.name = name
 
         self._subframes = 0
+        self._average = 0
 
         # Create the object
         obj = self._create_object()

--- a/ggmolvis/sceneobjects/molecules.py
+++ b/ggmolvis/sceneobjects/molecules.py
@@ -68,6 +68,7 @@ class Molecule(SceneObject):
             name=self.name, style=self._style_name
         )
         self.trajectory.subframes = self.subframes
+        self.trajectory.average = self.average
         self.trajectory.add_selection_from_atomgroup(
             self.atomgroup, name=self.name
         )


### PR DESCRIPTION
* Expose frame averaging as an alternative to the usage of subframes, as discussed at: https://github.com/yuxuanzhuang/ggmolvis/pull/16#issuecomment-2686533945.

* This mostly involved mimicking the infrastructure currently used to set subframes, minus a few changes we don't seem to need since the frame count remains unchanged.

* Although I usually try to keep PRs focused on one thing, I did take a stab at trying to improve the docs for `subframes` while adding in new docs for `average`. I believe the default value documented for `subframes` was also incorrect. These are a bit more verbose than the descriptions in the MN source at `molecularnodes/props.py`, just because I wanted a bit more detail for non-developer folks.

--------------

Additional notes:
1. It seems a bit awkward to me to have to fill in the boilerplate and docs in multiple places like this. That said, I didn't want to start a debate about the object-oriented design and instead wanted to focus on just getting the feature in.
2. Here is a sample diff I used to leverage the averaging functionality added in this branch over in the reference render script repo (https://github.com/tylerjereddy/render_north_star):

<details>

```diff
--- a/adk.yaml
+++ b/adk.yaml
@@ -15,7 +15,7 @@ mode: "movie"
 # depending on `mode`
 render_filename: "test"
 frame_start: 0
-frame_end: 285
+frame_end: 95
 # TODO: expand selection support beyond a single selection string
 sel_string: "all"
 background_color:
@@ -30,4 +30,8 @@ focal_length: 80
 # to continue to capture the same effective trajectory length;
 # so with subframes of 1 you would double upper frame bound,
 # with value of 2 you would triple, etc.
-subframes: 2
+subframes: 0
+# average can be increased for averaging positions over
+# flanking frames to help avoid i.e., "jittering" in movie renders;
+# in contrast to subframes, no additional frames are added
+average: 3
diff --git a/probe.py b/probe.py
index 62cf9df..41dae02 100644
--- a/probe.py
+++ b/probe.py
@@ -44,6 +44,7 @@ def main(p_config: dict):
     background_color = p_config["background_color"]
     focal_length = p_config["focal_length"]
     subframes = p_config["subframes"]
+    average = p_config["average"]
 
     if mode == "movie":
         outfile_suffix = "mp4"
@@ -56,6 +57,7 @@ def main(p_config: dict):
         bpy.context.scene.cycles.device = blender_engine_device
 
     ggmv = GGMolVis()
+    ggmv.average = average
     u = mda.Universe(topology_path, trajectory_path)
     system = u.select_atoms(sel_string)
     all_mol = ggmv.molecule(system, lens=focal_length)
```

</details>

3. Comparison of crude (just EEVEE for speed) trajectory movies with no averaging (https://youtube.com/shorts/XJR6CdDRKoU?feature=share) and 3-frame averaging (https://youtube.com/shorts/XKru0z-V6KY?feature=share) from the reference render script alongside this branch. Looks like a clear smoothing effect I think.
4. It isn't quite true that a user might not need to worry about frame count, even with averaging, since it seems the averaging may happen at N + average rather than flank + truncate at start and end, but this seems like an implementation detail, and molecular nodes is noisy about it without preventing the movie file from being generated--so I didn't add anything about this to the docs (but could..).

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
