### PR TITLE
WIP, ENH: user-contributed material demo

### DIFF
--- a/ggmolvis/material_contrib/__init__.py
+++ b/ggmolvis/material_contrib/__init__.py
@@ -1,0 +1,1 @@
+from . import metal

--- a/ggmolvis/material_contrib/metal.py
+++ b/ggmolvis/material_contrib/metal.py
@@ -1,0 +1,18 @@
+"""
+ggmolvis_metal: A metallic, shiny material.
+"""
+
+
+import bpy
+
+
+def material_generator():
+    material = bpy.data.materials.new(name="ggmolvis_metal")
+    material.use_nodes = True
+    material.node_tree.nodes.clear()
+    principled = material.node_tree.nodes.new("ShaderNodeBsdfPrincipled")
+    principled.inputs["Base Color"].default_value = (0.8, 0.8, 0.8, 1.0)  # Silvery color
+    principled.inputs["Metallic"].default_value = 0.95
+    principled.inputs["Roughness"].default_value = 0.1
+    output = material.node_tree.nodes.new("ShaderNodeOutputMaterial")
+    material.node_tree.links.new(principled.outputs["BSDF"], output.inputs["Surface"])

--- a/ggmolvis/properties/materials.py
+++ b/ggmolvis/properties/materials.py
@@ -4,6 +4,11 @@ from typing import Union
 from ..utils.node import set_mn_material
 from .base import Property
 from ..utils import materials_mapping, AVAILABLE_MATERIALS
+from ggmolvis import material_contrib
+
+
+# make approved user-contributed add-in materials available
+material_contrib.metal.material_generator()
 
 class Material(Property):
     """Class for the material."""

--- a/ggmolvis/utils/utils.py
+++ b/ggmolvis/utils/utils.py
@@ -147,7 +147,10 @@ materials_mapping = {
     "ambient": "MN Ambient Occlusion",
     # backdrop for all other shapes
     "backdrop": "Backdrop",
+    # user-contributed add-in materials
+    "metal": "ggmolvis_metal",
 }
+
 
 AVAILABLE_MATERIALS = materials_mapping.keys()
 


### PR DESCRIPTION
* This is perhaps a bit of a stretch, but it attempts to demonstrate a crude approach to user-contributed materials. This seems to be quite different from the current approach of using MN materials loaded from a binary `.blend` file upstream.

* I wasn't able to get the coloration to work with the custom material (because of deviation from the node structure used/expected by MN? not sure..). One advantage to having a script/text based approach to material generation is that provenance is made quite clear and version controlled vs. needing to extract from a binary file. That said, it may be largely impractical to do in `bpy`, not sure.

[ci skip]

A comparison of this new material vs. some of the more professional looking defaults available for ADK from the reference render script I'm using (https://github.com/tylerjereddy/render_north_star) is below. Sample diff in the render repo is below the fold (the render repo still uses world shader for background so I had to turn that off for now).

<details>

```diff
--- a/adk.yaml
+++ b/adk.yaml
@@ -35,4 +35,4 @@ subframes: 2
 # default -- looks professional
 # ambient -- also looks professional
 # squishy -- a plastic-like appearance, pretty neat!
-material: "default"
+material: "metal"
diff --git a/probe.py b/probe.py
index f998b0a..ffa684f 100644
--- a/probe.py
+++ b/probe.py
@@ -70,10 +70,10 @@ def main(p_config: dict):
     bpy.context.scene.frame_start = frame_start
     bpy.context.scene.frame_end = frame_end
 
-    set_background(rgba=(background_color["red"],
-                         background_color["green"],
-                         background_color["blue"],
-                         background_color["alpha"]))
+    #set_background(rgba=(background_color["red"],
+                         #background_color["green"],
+                         #background_color["blue"],
+                         #background_color["alpha"]))
```

</details>


"default":
![image](https://github.com/user-attachments/assets/61189978-0cdf-4928-b3ae-837a648c51dc)



"squishy":
![image](https://github.com/user-attachments/assets/3fcb8bb6-ce61-46be-b3ee-bf47ebef0f7f)


"metal":
![image](https://github.com/user-attachments/assets/0a68c7a7-9430-4753-828a-50a178566a61)
