### PR TITLE
WIP, ENH: frame number via compositor

### DIFF
--- a/ggmolvis/camera.py
+++ b/ggmolvis/camera.py
@@ -19,7 +19,7 @@ from .base import GGMolvisArtist
 from .world import World, Location, Rotation
 from . import SESSION
 from .renderer import Renderer, MovieRenderer
-from .compositor import _set_compositor_bg
+from .compositor import _set_compositor_bg, _create_frame_image, _composit_frame_label
 
 class Camera(GGMolvisArtist):
     """Class for the camera."""
@@ -54,6 +54,7 @@ class Camera(GGMolvisArtist):
     def _update_frame(self, frame_number):
         """Update the camera's state for the given frame"""
         self.world._apply_to(self.object, frame_number)
+        self.frame_number = frame_number
     
     def set_view(self):
         """Set the current view to this camera"""
@@ -84,7 +85,8 @@ class Camera(GGMolvisArtist):
                frame=None,
                filepath=None,
                resolution=(640, 360),
-               composite_bg_rgba=None):
+               composite_bg_rgba=None,
+               add_frame_numbers=None):
         """Render the scene with this camera"""
         bpy.context.scene.camera = self.object
         if frame is not None:
@@ -92,6 +94,13 @@ class Camera(GGMolvisArtist):
 
         if composite_bg_rgba is not None:
            _set_compositor_bg(composite_bg_rgba)
+
+        if add_frame_numbers is not None:
+            img_path = _create_frame_image(frame_number=self.frame_number,
+                                           width=resolution[0],
+                                           height=resolution[1],
+                                           text=f"frame: {self.frame_number}")
+            _composit_frame_label(img_path=img_path)
 
         if mode == 'image':        
             renderer = Renderer(resolution=resolution,

--- a/ggmolvis/compositor.py
+++ b/ggmolvis/compositor.py
@@ -1,4 +1,8 @@
+import os
+
+
 import bpy
+from PIL import Image, ImageDraw, ImageFont
 
 
 def _set_compositor_bg(rgba: tuple[float, float, float, float]):
@@ -29,3 +33,37 @@ def _set_compositor_bg(rgba: tuple[float, float, float, float]):
     links.new(render_layers.outputs['Alpha'], mix_node.inputs[0])
     links.new(render_layers.outputs['Image'], mix_node.inputs[2])
     links.new(mix_node.outputs[0], composite.inputs[0])
+
+
+def _create_frame_image(frame_number: int,
+                        width: int,
+                        height: int,
+                        text: str):
+    img = Image.new('RGBA', (width, height), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    font = ImageFont.truetype("/System/Library/Fonts/Geneva.ttf", 80)
+    text_bbox = draw.textbbox((0, 0), text, font=font)
+    text_width = text_bbox[2] - text_bbox[0]
+    text_height = text_bbox[3] - text_bbox[1]
+    x = (width - text_width) // 2
+    y = height - text_height - 40
+    draw.text((x, y), text, font=font, fill=(255, 255, 255, 255))
+    os.makedirs("frame_overlays", exist_ok=True)
+    out_path = os.path.join("frame_overlays", f"frame_{frame_number}.png")
+    img.save(out_path, "PNG")
+    return out_path
+
+def _composit_frame_label(img_path):
+    scene = bpy.context.scene
+    scene.use_nodes = True
+    tree = scene.node_tree
+    links = tree.links
+    tree.nodes.clear()
+    render_layers = tree.nodes.new('CompositorNodeRLayers')
+    image_node = tree.nodes.new('CompositorNodeImage')
+    alpha_over = tree.nodes.new('CompositorNodeAlphaOver')
+    composite = tree.nodes.new('CompositorNodeComposite')
+    image_node.image = bpy.data.images.load(img_path)
+    links.new(render_layers.outputs['Image'], alpha_over.inputs[2])
+    links.new(image_node.outputs['Image'], alpha_over.inputs[1])
+    links.new(alpha_over.outputs['Image'], composite.inputs['Image'])


### PR DESCRIPTION
* Based on discussion in #27, and as an alternative to #14, this is a demo for using external image generation followed by a compositor step to overlay the image that contains nothing but the frame number in it.

* Predictably, as recently noted at https://github.com/yuxuanzhuang/ggmolvis/pull/21#discussion_r1972585038, this ablates the background coloring that also uses the compositor. It seemed fairly obvious to me that this would happen, even as non-expert, if we just naively use the compositor for isolated purposes that try to ignore each other. I guess I can't escape the node connection reality under the hood as much as I'd like to.

[ci skip]

I'm assuming that there was also some desire to screen capture `blf`-placed labels as well and get them into the render in some roundabout way, but the current approach is even cruder and just produces empty images with frame numbers at the bottom using an external lib.

For still images, it seems more resilient to changes in focal length:

Focal length 110:

<details>

![image](https://github.com/user-attachments/assets/a0cacd67-18e2-4cea-8e3a-0980b311fcba)

</details>

Focal length 80: 

<details>

![image](https://github.com/user-attachments/assets/efa6c25a-997f-4b1c-948b-11e1d82f4c1e)

</details>

Focal length 10:

<details>

![image](https://github.com/user-attachments/assets/640e12a3-2e91-4b82-9310-2529d46af724)

</details>

