### PR TITLE
WIP, ENH: early draft of color support

### DIFF
--- a/ggmolvis/properties/colors.py
+++ b/ggmolvis/properties/colors.py
@@ -8,6 +8,10 @@ from .base import Property
 class Color(Property):
     """Class for the color."""
 
+
+    def __init__(self, mol_obj, color):
+        self.colors = [color]
+
     # TODO: implement
     def _set_property(self):
         color_name = self.property_name

--- a/ggmolvis/utils/node.py
+++ b/ggmolvis/utils/node.py
@@ -2,6 +2,12 @@ import bpy
 import molecularnodes as mn
 from molecularnodes.blender.nodes import swap, assign_material, add_custom
 
+
+color_dict = {"green": (0, 0.9, 0, 1.0),
+              "red": (1, 0, 0, 1.0),
+              "default": (0, 0, 0, 1.0),
+             }
+
 def extract_mn_node(object: bpy.types.Object):
     """Extract the node group from the MN object."""
     nodes_mn = object.modifiers["MolecularNodes"].node_group
@@ -53,6 +59,7 @@ def set_mn_color(object, color):
     # cannot remove link with
     if color_node.inputs["Color"].links:
         nodes_mn.links.remove(color_node.inputs["Color"].links[0])
+    color = color_dict[color]
     color_node.inputs['Color'].default_value = color
 
 def set_mn_material(object, material):


### PR DESCRIPTION
* The option to set the color of a `molecule` is pretty important for visual separation/clarity of i.e., MDAnalysis selections in `ggmolvis`. This is a likely-incorrect but fairly minimal set of demo changes that allows the color setting to work per molecule/selection for image renders (probably not movies yet) while still passing the tests locally.

[ci skip]

This branch was developed alongside the reference render script for flu virus visualization at https://github.com/tylerjereddy/render_north_star/pull/3.

A sample render separating lipid and protein colors is below--does seem to be looking a bit nicer than default already. That said, there are still many improvements/fixes needed. For whatever reason, the `metal` surface option from #23 seems to be ignored with the default settings for this system--that's annoying...

![image](https://github.com/user-attachments/assets/bb1b5617-9ed5-4e3a-aef7-ba113715f881)

