### PR TITLE
WIP, ENH: draft color support on material

### DIFF
--- a/ggmolvis/properties/base.py
+++ b/ggmolvis/properties/base.py
@@ -13,6 +13,7 @@ class Property(GGMolvisArtist):
         self._scene_object = scene_object
         self._property_name = property_name
         self._set_property()
+        self.color = kwargs.get("color")
 
     @abstractmethod
     def _set_property(self):

--- a/ggmolvis/properties/materials.py
+++ b/ggmolvis/properties/materials.py
@@ -35,7 +35,21 @@ class Material(Property):
     def _apply_to(self, obj, frame: int = 0):
         obj.data.materials.append(self.material)
     
-    def _modify_material(self, material, frame: int = 0):
+    def _modify_material(self, material, frame: int = 0,
+                         color=None):
+        color_dict = {"violet": (0.58, 0.0, 0.827, 1.0),
+                      "green": (0, 0.9, 0.0, 1.0),
+                      "red": (0.9, 0.0, 0.0, 1.0),
+                      "blue": (0.0, 0.0, 0.9, 1.0),
+                      "black": (0.0, 0.0, 0.0, 1.0),
+                      "default": (0.0, 0.0, 0.0, 1.0),
+                      }
+        if color is not None:
+            material.node_tree.nodes.clear()
+            principled = material.node_tree.nodes.new("ShaderNodeBsdfPrincipled")
+            principled.inputs["Base Color"].default_value = color_dict[color]
+            output = material.node_tree.nodes.new("ShaderNodeOutputMaterial")
+            material.node_tree.links.new(principled.outputs["BSDF"], output.inputs["Surface"])
         for key, values in self.material_modifier.items():
             # if values is a number
             if isinstance(values, (int, float)):
@@ -75,5 +89,7 @@ class MoleculeMaterial(Material):
     def _apply_to(self, obj, frame: int = 0):
         """Apply material to the object."""
 
+        if self.color is None:
+            self.color = "black"
         set_mn_material(obj, self.material_name)
-        self._modify_material(self.material, frame)
+        self._modify_material(self.material, frame, color=self.color)

--- a/ggmolvis/sceneobjects/base.py
+++ b/ggmolvis/sceneobjects/base.py
@@ -56,7 +56,7 @@ class SceneObject(GGMolvisArtist):
         self.name = obj.name
 
         self._init_color(color)
-        self._init_material(material)
+        self._init_material(material, color)
         self._init_style(style)
 
         self.world._apply_to(self.object)

--- a/ggmolvis/sceneobjects/molecules.py
+++ b/ggmolvis/sceneobjects/molecules.py
@@ -55,8 +55,8 @@ class Molecule(SceneObject):
     def _init_style(self, style="default"):
         self._style = MoleculeStyle(self, style)
 
-    def _init_material(self, material="default"):
-        self._material = MoleculeMaterial(self, material)
+    def _init_material(self, material="default", color=None):
+        self._material = MoleculeMaterial(self, material, color=color)
 
     def _init_color(self, color="black"):
         self._color = MoleculeColor(self, color)


### PR DESCRIPTION
* This is an alternative approach to color setting, happening on the material in this case, based on the feedback from Brady in gh-31. This approach passes the testsuite locally and achieves coloring results that match those from the alternate PR.

[ci skip]

