### PR TITLE
TST: add render testing, mark as xslow

### DIFF
--- a/ggmolvis/__init__.py
+++ b/ggmolvis/__init__.py
@@ -6,6 +6,7 @@ Molecular visualization with Blender
 import os
 import shutil
 import tempfile
+import uuid
 from importlib.metadata import version
 import bpy
 from bpy.app.handlers import frame_change_pre
@@ -45,7 +46,8 @@ base_name = 'ggmolvis.blend'
 #count += 1
 
 # we will save the current session to the temporary directory
-dest_dir = tempfile.gettempdir()
+dest_dir = f"{tempfile.gettempdir()}{uuid.uuid4()}"
+os.makedirs(dest_dir, exist_ok=True)
 dest_path = os.path.join(dest_dir, base_name)
 logger.debug(f"Blend file stored at {dest_path}")
 

--- a/ggmolvis/__init__.py
+++ b/ggmolvis/__init__.py
@@ -46,7 +46,7 @@ base_name = 'ggmolvis.blend'
 #count += 1
 
 # we will save the current session to the temporary directory
-dest_dir = f"{tempfile.gettempdir()}{uuid.uuid4()}"
+dest_dir = f"{tempfile.gettempdir()}/{uuid.uuid4()}"
 os.makedirs(dest_dir, exist_ok=True)
 dest_path = os.path.join(dest_dir, base_name)
 logger.debug(f"Blend file stored at {dest_path}")

--- a/ggmolvis/tests/conftest.py
+++ b/ggmolvis/tests/conftest.py
@@ -7,9 +7,22 @@ Global pytest fixtures
 # More information at
 # https://docs.pytest.org/en/stable/how-to/fixtures.html#scope-sharing-fixtures-across-classes-modules-packages-or-session
 
+import os
 import pytest
 
 @pytest.fixture
 def ggmv():
     from ggmolvis import GGMolVis
     return GGMolVis()
+
+
+def pytest_runtest_setup(item):
+    mark = item.get_closest_marker("xslow")
+    if mark is not None:
+        try:
+            v = int(os.environ.get('GGMOLVIS_XSLOW', '0'))
+        except ValueError:
+            v = False
+        if not v:
+            pytest.skip("very slow test; "
+                        "set environment variable GGMOLVIS_XSLOW=1 to run it")

--- a/ggmolvis/tests/test_render.py
+++ b/ggmolvis/tests/test_render.py
@@ -1,5 +1,8 @@
 from ggmolvis.ggmolvis import GGMolVis
 from ggmolvis.tests.data import PSF, DCD
+from MDAnalysisTests.datafiles import GRO
+from PIL import Image
+import numpy as np
 
 from MDAnalysis import Universe
 from ggmolvis.utils import MOL_AVAILABLE_STYLES, AVAILABLE_MATERIALS
@@ -76,3 +79,30 @@ def test_render_error_frame_range(ggmv, atomgroup, render_mp4):
         ggmv.render(mol, frame_range=(0, 4),
                         resolution=(300, 200),
                         filepath=render_mp4)
+
+
+@cleanup
+@pytest.mark.xslow
+def test_render_basic_bg(tmpdir):
+    # confirm correct propagation of background color
+    # and image size specified
+    ggmv = GGMolVis()
+    u = Universe(GRO)
+    mol = ggmv.molecule(u.atoms)
+    with tmpdir.as_cwd():
+        ggmv.render(object=mol,
+                    resolution=(50, 50),
+                    filepath=f"test_red.png",
+                    mode="image",
+                    # red background
+                    composite_bg_rgba=(0.9, 0, 0, 1.0),
+                    lens=35)
+        with Image.open("test_red.png") as img:
+            img_array = np.array(img)
+            red = img_array[..., 0]
+            green = img_array[..., 1]
+            blue = img_array[..., 2]
+    # red should be the dominant channel
+    assert red.sum() > (green.sum() + blue.sum())
+    # image size should be 50 x 50 x 4 channels
+    assert img_array.size == 10_000

--- a/ggmolvis/tests/test_render.py
+++ b/ggmolvis/tests/test_render.py
@@ -83,10 +83,9 @@ def test_render_error_frame_range(ggmv, atomgroup, render_mp4):
 
 @cleanup
 @pytest.mark.xslow
-def test_render_basic_bg(tmpdir):
+def test_render_basic_bg(tmpdir, ggmv):
     # confirm correct propagation of background color
     # and image size specified
-    ggmv = GGMolVis()
     u = Universe(GRO)
     mol = ggmv.molecule(u.atoms)
     with tmpdir.as_cwd():

--- a/ggmolvis/tests/utils.py
+++ b/ggmolvis/tests/utils.py
@@ -27,7 +27,7 @@ def _clean_up(ggmv):
                 ggmv._session.remove(artist.trajectory.uuid)
             except Exception:
                 pass
-    bpy.ops.wm.read_homefile(app_template="")
+    bpy.ops.wm.open_mainfile(filepath=bpy.data.filepath)
     ggmv._session.prune()
     ggmv._session._ggmolvis = set()
     ggmv._initialized = False

--- a/ggmolvis/tests/utils.py
+++ b/ggmolvis/tests/utils.py
@@ -27,6 +27,7 @@ def _clean_up(ggmv):
                 ggmv._session.remove(artist.trajectory.uuid)
             except Exception:
                 pass
+    bpy.ops.wm.read_homefile(app_template="")
     ggmv._session.prune()
     ggmv._session._ggmolvis = set()
     ggmv._initialized = False

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+
+markers =
+    xslow: mark test as extremely slow (not run unless explicitly requested)


### PR DESCRIPTION
* This adds the first test that actually makes assertions about the pixel content of `ggmolvis`-rendered images. It turns out that regular render calls do "ok" (slow, but works) in GitHub actions, but if you use the compositor there seem to be issues (hard crashing). Since the test added here uses the compositor to set the background color, it is marked `xslow` so that the user/developer must opt in to run it (and it doesn't run in CI, by default).

* This approach has the advantage that we can start marking assertions about the expected appearance of renders, but of course it has the drawback that we can only run these tests locally for now (or using one of the services that offers GPU CI runners, which some larger OSS projects do, but usually has a cost). I think it is still better than nothing given that we could at least bisect on newly-introduced problems locally even if it is unfortunately rather easy for bugs to slip past the CI this way. This is a common approach upstream for tests that are not CI tractable (i.e., incredibly slow, or require unreasonably large amounts of memory to reproduce the original problem).

* For a bit of a dissection on composition causing crashes in GHA CI, see recent testing on my fork at:
https://github.com/tylerjereddy/ggmolvis/pull/1


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
